### PR TITLE
Fix cross-environment timer and plan detection

### DIFF
--- a/src/utils/TimerManager.ts
+++ b/src/utils/TimerManager.ts
@@ -21,9 +21,9 @@ interface TimerConfig {
 class TimerManager {
   private static instance: TimerManager;
   private timers = new Map<string, TimerConfig>();
-  private intervals = new Map<string, NodeJS.Timeout>();
+  private intervals = new Map<string, ReturnType<typeof setInterval>>();
   private isRunning = false;
-  private masterInterval: NodeJS.Timeout | null = null;
+  private masterInterval: ReturnType<typeof setInterval> | null = null;
 
   private constructor() {}
 
@@ -313,7 +313,8 @@ class TimerManager {
    */
   autoOptimize(): void {
     const stats = this.getStatus();
-    const memoryUsage = process.memoryUsage();
+    const nodeProcess = typeof globalThis !== 'undefined' ? (globalThis as any).process : undefined;
+    const memoryUsage = nodeProcess && typeof nodeProcess.memoryUsage === 'function' ? nodeProcess.memoryUsage() : { heapUsed: 0, heapTotal: 1 };
     const memoryPercent = (memoryUsage.heapUsed / memoryUsage.heapTotal) * 100;
     
     // 메모리 사용률이 80% 이상이거나 활성 타이머가 20개 이상이면 최적화

--- a/src/utils/VercelPlanDetector.ts
+++ b/src/utils/VercelPlanDetector.ts
@@ -82,8 +82,9 @@ export class VercelPlanDetector {
    */
   private async detectByEnvironmentVariables(): Promise<Partial<VercelPlanInfo>> {
     try {
+      const nodeProcess = typeof globalThis !== 'undefined' ? (globalThis as any).process : undefined;
       // 직접적인 플랜 정보
-      const vercelPlan = process.env.NEXT_PUBLIC_VERCEL_PLAN || process.env.VERCEL_PLAN;
+      const vercelPlan = nodeProcess?.env?.NEXT_PUBLIC_VERCEL_PLAN || nodeProcess?.env?.VERCEL_PLAN;
       if (vercelPlan) {
         return {
           plan: vercelPlan as any,
@@ -93,9 +94,9 @@ export class VercelPlanDetector {
       }
 
       // Vercel 환경 감지
-      const isVercel = process.env.VERCEL === '1';
-      const vercelUrl = process.env.VERCEL_URL;
-      const vercelEnv = process.env.VERCEL_ENV;
+      const isVercel = nodeProcess?.env?.VERCEL === '1';
+      const vercelUrl = nodeProcess?.env?.VERCEL_URL;
+      const vercelEnv = nodeProcess?.env?.VERCEL_ENV;
 
       if (isVercel) {
         // 도메인 패턴으로 플랜 추정
@@ -137,8 +138,9 @@ export class VercelPlanDetector {
    */
   private async detectByMemoryLimits(): Promise<Partial<VercelPlanInfo>> {
     try {
-      if (typeof process !== 'undefined' && process.memoryUsage) {
-        const memUsage = process.memoryUsage();
+      const nodeProcess = typeof globalThis !== 'undefined' ? (globalThis as any).process : undefined;
+      if (nodeProcess && typeof nodeProcess.memoryUsage === 'function') {
+        const memUsage = nodeProcess.memoryUsage();
         const totalMemory = memUsage.heapTotal + memUsage.external;
 
         // Hobby: ~50MB, Pro: ~1GB, Enterprise: ~3GB+


### PR DESCRIPTION
## Summary
- avoid direct usage of `process` in `VercelPlanDetector`
- switch `TimerManager` to use `setInterval` return type
- guard memory usage lookup when optimizing timers

## Testing
- `npm run type-check` *(fails: Cannot find module '@faker-js/faker', etc.)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d13887948325a6cf5c91305758bf