### PR TITLE
Remove defunct deployment report link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,6 @@ curl -X POST https://openmanager-vibe-v5.vercel.app/api/v3/ai \
 ```
 
 ### 📝 **문서 업데이트**
-- **[AI_ENGINE_V3_DEPLOYMENT_SUCCESS_REPORT.md](./AI_ENGINE_V3_DEPLOYMENT_SUCCESS_REPORT.md)** - v3.0 배포 성공 종합 보고서
 - **[README.md](./README.md)** - AI 엔진 v3.0 내용 반영
 - 기술 스택 및 아키텍처 문서 업데이트
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,6 @@ docker run -p 3000:3000 openmanager-vibe
 
 ## 📚 **문서**
 
-- **[AI_ENGINE_V3_DEPLOYMENT_SUCCESS_REPORT.md](./AI_ENGINE_V3_DEPLOYMENT_SUCCESS_REPORT.md)** - v3.0 배포 성공 보고서
 - **[DEPLOY_GUIDE.md](./DEPLOY_GUIDE.md)** - 상세 배포 가이드
 - **[API Documentation](./docs/api/)** - API 상세 문서
 - **[CHANGELOG.md](./CHANGELOG.md)** - 변경 사항 로그


### PR DESCRIPTION
## Summary
- remove references to `AI_ENGINE_V3_DEPLOYMENT_SUCCESS_REPORT.md` because that file does not exist

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6840d5db55bc8325a4c6631db556da33