### PR TITLE
Implement dev-only report clearing

### DIFF
--- a/src/app/api/ai-agent/learning/continuous/route.ts
+++ b/src/app/api/ai-agent/learning/continuous/route.ts
@@ -259,8 +259,9 @@ export async function DELETE(request: NextRequest) {
       case 'clear-reports': {
         // 보고서 히스토리 삭제 (개발 환경에서만)
         if (process.env.NODE_ENV === 'development') {
-          // TODO: 보고서 히스토리 삭제 구현
-          
+          const continuousLearningService = ContinuousLearningService.getInstance();
+          continuousLearningService.clearReportHistory();
+
           return NextResponse.json({
             success: true,
             message: '보고서 히스토리가 삭제되었습니다.'

--- a/src/services/ai-agent/ContinuousLearningService.ts
+++ b/src/services/ai-agent/ContinuousLearningService.ts
@@ -341,6 +341,16 @@ export class ContinuousLearningService {
   }
 
   /**
+   * 보고서 히스토리 초기화
+   */
+  clearReportHistory(): void {
+    this.reportHistory = [];
+    if (process.env.NODE_ENV === 'development') {
+      console.log('🗑️ [ContinuousLearningService] 보고서 히스토리 초기화');
+    }
+  }
+
+  /**
    * 설정 업데이트
    */
   async updateConfig(newConfig: Partial<ContinuousLearningConfig>): Promise<void> {


### PR DESCRIPTION
## Summary
- implement `clearReportHistory` method
- hook dev-only deletion logic into `clear-reports` API action

## Testing
- `npm run test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6840e1d3df888325bec74a91111dc517