### PR TITLE
Enable transformers pipeline with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,8 @@
     "vitest": "^3.1.4",
     "ws": "^8.18.2",
     "zod": "^3.25.46",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "@xenova/transformers": "^2.12.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/services/ai/IntentClassifier.test.ts
+++ b/src/services/ai/IntentClassifier.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@xenova/transformers', () => {
+  const pipelineMock = vi.fn(async () => vi.fn(async () => ({ labels: ['test'], scores: [1] })));
+  return { pipeline: pipelineMock };
+});
+
+import { IntentClassifier } from './IntentClassifier';
+
+describe('IntentClassifier 초기화', () => {
+  it('브라우저 환경에서 pipeline이 호출되어야 함', async () => {
+    const classifier = new IntentClassifier();
+    await classifier.initialize();
+
+    const status = classifier.getStatus();
+    expect(status.initialized).toBe(true);
+    expect(status.engine).toBe('transformers.js');
+
+    const { pipeline } = await import('@xenova/transformers');
+    const calls = (pipeline as any).mock.calls;
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        ['zero-shot-classification', 'Xenova/distilbert-base-uncased-mnli'],
+        ['token-classification', 'Xenova/bert-base-NER'],
+      ])
+    );
+  });
+});

--- a/src/services/ai/IntentClassifier.ts
+++ b/src/services/ai/IntentClassifier.ts
@@ -18,18 +18,21 @@ export class IntentClassifier {
     if (this.initialized) return;
     
     try {
-      // 브라우저 환경에서만 Transformers.js 로드 (임시 비활성화)
-      if (false && typeof window !== 'undefined') {
-        // TODO: @xenova/transformers 패키지 재설치 후 활성화
-        // const { pipeline } = await import('@xenova/transformers');
-        
+      // 브라우저 환경에서만 Transformers.js 로드
+      if (typeof window !== 'undefined') {
+        const { pipeline } = await import('@xenova/transformers');
+
         // 🤗 의도 분류용 모델 (경량화)
-        // this.classifier = await pipeline('zero-shot-classification', 
-        //   'Xenova/distilbert-base-uncased-mnli');
-        
-        // 🏷️ 엔티티 추출용 모델  
-        // this.nerModel = await pipeline('token-classification',
-        //   'Xenova/bert-base-NER');
+        this.classifier = await pipeline(
+          'zero-shot-classification',
+          'Xenova/distilbert-base-uncased-mnli'
+        );
+
+        // 🏷️ 엔티티 추출용 모델
+        this.nerModel = await pipeline(
+          'token-classification',
+          'Xenova/bert-base-NER'
+        );
       }
       
       this.initialized = true;


### PR DESCRIPTION
## Summary
- enable pipeline call in `IntentClassifier`
- add `@xenova/transformers` dependency
- add browser initialization test for `IntentClassifier`

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6840e1db46748325a41945e8c727019b