### PR TITLE
Update env var for AI engine

### DIFF
--- a/docs/3_INSTALLATION_AND_SETUP.md
+++ b/docs/3_INSTALLATION_AND_SETUP.md
@@ -121,7 +121,7 @@ PORT=3001
 # AI 엔진 설정 (선택사항)
 PYTHON_PATH=python3
 AI_ENGINE_MODE=optimized
-AI_ENGINE_URL=https://your-python-service.onrender.com
+FASTAPI_BASE_URL=https://your-python-service.onrender.com
 
 # 데이터베이스 설정 (선택사항)
 # Supabase 또는 기타 PostgreSQL
@@ -144,7 +144,7 @@ VERCEL_PLAN=hobby  # 또는 pro
 
 # AI 엔진 (프로덕션)
 AI_ENGINE_MODE=production
-AI_ENGINE_URL=https://your-production-ai-service.com
+FASTAPI_BASE_URL=https://your-production-ai-service.com
 
 # 보안 설정
 ADMIN_PIN=your_secure_pin

--- a/docs/4_AI_AGENT_GUIDE.md
+++ b/docs/4_AI_AGENT_GUIDE.md
@@ -802,7 +802,7 @@ curl http://localhost:3001/api/ai-agent/admin/metrics
 
 #### 일반적인 문제
 1. **Python 엔진 연결 실패**
-   - 환경 변수 `AI_ENGINE_URL` 확인
+   - 환경 변수 `FASTAPI_BASE_URL` 확인
    - 네트워크 연결 상태 확인
    - TypeScript 폴백으로 자동 전환됨
 

--- a/docs/6_TESTING_AND_DEPLOYMENT.md
+++ b/docs/6_TESTING_AND_DEPLOYMENT.md
@@ -326,7 +326,7 @@ describe('MCP Integration', () => {
 
   it('Python 엔진 실패 시 TypeScript 폴백이 작동한다', async () => {
     // Python 엔진 URL을 잘못된 값으로 설정
-    process.env.AI_ENGINE_URL = 'http://invalid-url:9999';
+    process.env.FASTAPI_BASE_URL = 'http://invalid-url:9999';
 
     const request = {
       query: 'CPU 분석',

--- a/docs/7_TROUBLESHOOTING.md
+++ b/docs/7_TROUBLESHOOTING.md
@@ -79,7 +79,7 @@ npm run clean:ports
 **해결 방법:**
 ```bash
 # 1. Python 엔진 연결 확인
-curl $AI_ENGINE_URL/health
+curl $FASTAPI_BASE_URL/health
 
 # 2. TypeScript 폴백 테스트
 curl http://localhost:3001/api/ai-agent/integrated

--- a/scripts/test-warmup.sh
+++ b/scripts/test-warmup.sh
@@ -4,7 +4,7 @@ echo "🔥 AI 시스템 웜업 및 온/오프 테스트 시작..."
 echo "================================================"
 
 # Python 서비스 URL
-PYTHON_URL="https://openmanager-vibe-v5.onrender.com"
+PYTHON_URL="https://openmanager-ai-engine.onrender.com"
 LOCAL_URL="http://localhost:3000"
 
 echo ""

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
     const body: AIAnalysisRequest = await request.json();
     
     // AI Engine URL 가져오기
-    const aiEngineUrl = process.env.AI_ENGINE_URL;
+    const aiEngineUrl = process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com';
     
     if (!aiEngineUrl) {
       return NextResponse.json(
@@ -78,7 +78,7 @@ export async function POST(request: NextRequest) {
 
 // GET 요청으로 상태 확인
 export async function GET() {
-  const aiEngineUrl = process.env.AI_ENGINE_URL;
+  const aiEngineUrl = process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com';
   
   try {
     if (!aiEngineUrl) {

--- a/src/app/api/system/python-warmup/route.ts
+++ b/src/app/api/system/python-warmup/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 export async function POST(request: NextRequest) {
   try {
     // Python Render 서비스 수동 웜업
-    const pythonServiceUrl = process.env.AI_ENGINE_URL || 'https://openmanager-vibe-v5.onrender.com';
+    const pythonServiceUrl = process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com';
     const startTime = Date.now();
     
     console.log('🔧 Python 수동 웜업 API 요청');
@@ -92,7 +92,7 @@ export async function POST(request: NextRequest) {
 export async function GET() {
   // 현재 Python 서비스 상태 확인
   try {
-    const pythonServiceUrl = process.env.AI_ENGINE_URL || 'https://openmanager-vibe-v5.onrender.com';
+    const pythonServiceUrl = process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com';
     
     const response = await fetch(`${pythonServiceUrl}/health`, {
       method: 'GET',
@@ -116,7 +116,7 @@ export async function GET() {
     return NextResponse.json({
       success: true,
       data: {
-        pythonServiceUrl: process.env.AI_ENGINE_URL || 'https://openmanager-vibe-v5.onrender.com',
+        pythonServiceUrl: process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com',
         isActive: false,
         status: 'sleeping',
         warmupMode: 'on-demand',

--- a/src/app/api/v1/backend/performance/route.ts
+++ b/src/app/api/v1/backend/performance/route.ts
@@ -11,7 +11,7 @@ import { PythonMLBridge } from '@/services/python-bridge/ml-bridge';
 let pythonBridge: PythonMLBridge | null = null;
 function getPythonBridge(): PythonMLBridge {
   if (!pythonBridge) {
-    pythonBridge = new PythonMLBridge(process.env.AI_ENGINE_URL || 'https://openmanager-vibe-v5.onrender.com');
+    pythonBridge = new PythonMLBridge(process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com');
   }
   return pythonBridge;
 }
@@ -188,7 +188,7 @@ async function getSpecificMetric(metric: string) {
         data: {
           health,
           metrics: bridge.getMetrics(),
-          url: process.env.AI_ENGINE_URL || 'https://openmanager-vibe-v5.onrender.com'
+          url: process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com'
         },
         collectionTime: Date.now() - startTime
       });
@@ -241,7 +241,7 @@ async function handlePerformanceAction(action: string) {
         python: {
           health: pythonHealth,
           metrics: pythonMetrics,
-          url: process.env.AI_ENGINE_URL
+          url: process.env.FASTAPI_BASE_URL
         },
         timestamp: new Date().toISOString()
       });
@@ -352,7 +352,7 @@ async function resetPythonBridge() {
   const result = {
     reset: true,
     health,
-    url: process.env.AI_ENGINE_URL,
+    url: process.env.FASTAPI_BASE_URL,
     timestamp: new Date().toISOString()
   };
   
@@ -448,7 +448,7 @@ async function warmupPython() {
       success: health,
       warmupTime,
       pythonHealth: health,
-      url: process.env.AI_ENGINE_URL
+      url: process.env.FASTAPI_BASE_URL
     };
     
     console.log('✅ Python 웜업 완료:', result);

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -46,7 +46,7 @@ export interface AlertData {
 export const useWebSocket = (config: WebSocketConfig = {}) => {
   const {
     url = process.env.NODE_ENV === 'production' 
-      ? 'https://openmanager-vibe-v5.onrender.com'
+      ? 'https://openmanager-ai-engine.onrender.com'
       : 'http://localhost:3000',
     autoConnect = true,
     reconnectAttempts = 5,

--- a/src/services/ai/MCPAIRouter.ts
+++ b/src/services/ai/MCPAIRouter.ts
@@ -384,7 +384,7 @@ export class MCPAIRouter {
   private async warmupPythonService(): Promise<void> {
     if (this.pythonServiceWarmedUp) return;
     
-    const pythonServiceUrl = process.env.AI_ENGINE_URL || 'https://openmanager-vibe-v5.onrender.com';
+    const pythonServiceUrl = process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com';
     const startTime = Date.now();
     
     try {
@@ -474,7 +474,7 @@ export class MCPAIRouter {
    */
   private async performWarmupAnalysis(): Promise<void> {
     try {
-      const pythonServiceUrl = process.env.AI_ENGINE_URL || 'https://openmanager-vibe-v5.onrender.com';
+      const pythonServiceUrl = process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com';
       
       const response = await fetch(`${pythonServiceUrl}/analyze`, {
         method: 'POST',

--- a/src/services/ai/MonitoringService.ts
+++ b/src/services/ai/MonitoringService.ts
@@ -325,7 +325,7 @@ export class MonitoringService {
     
     // 🔧 Python 서비스 체크 - 실패해도 전체 시스템에 영향 없음
     try {
-      const pythonServiceUrl = process.env.AI_ENGINE_URL || 'https://openmanager-vibe-v5.onrender.com';
+      const pythonServiceUrl = process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com';
       const startTime = Date.now();
       
       const response = await fetch(`${pythonServiceUrl}/health`, {

--- a/src/services/ai/PythonWarmupService.ts
+++ b/src/services/ai/PythonWarmupService.ts
@@ -19,7 +19,7 @@ export class PythonWarmupService {
   private pythonServiceUrl: string;
 
   private constructor() {
-    this.pythonServiceUrl = process.env.AI_ENGINE_URL || 'https://openmanager-vibe-v5.onrender.com';
+    this.pythonServiceUrl = process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com';
     this.warmupStatus = {
       isWarm: false,
       lastWarmup: new Date(0),

--- a/src/services/ai/TaskOrchestrator.ts
+++ b/src/services/ai/TaskOrchestrator.ts
@@ -178,7 +178,7 @@ export class TaskOrchestrator {
       const structuredRequest = this.createStructuredRequest(task);
       
       // 환경변수에서 Python 서비스 URL 가져오기
-      const pythonServiceUrl = process.env.AI_ENGINE_URL || 'https://openmanager-vibe-v5.onrender.com';
+      const pythonServiceUrl = process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com';
       
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), task.timeout || 20000);
@@ -543,7 +543,7 @@ export class TaskOrchestrator {
 
   async checkPythonStatus(): Promise<boolean> {
     try {
-      const pythonServiceUrl = process.env.AI_ENGINE_URL || 'https://openmanager-vibe-v5.onrender.com';
+      const pythonServiceUrl = process.env.FASTAPI_BASE_URL || 'https://openmanager-ai-engine.onrender.com';
       const response = await fetch(`${pythonServiceUrl}/health`, { 
         method: 'GET',
         signal: AbortSignal.timeout(5000)

--- a/src/services/websocket/WebSocketManager.ts
+++ b/src/services/websocket/WebSocketManager.ts
@@ -67,7 +67,7 @@ export class WebSocketManager {
     this.io = new SocketIOServer(server, {
       cors: {
         origin: process.env.NODE_ENV === 'production' 
-          ? ['https://openmanager-vibe-v5.vercel.app', 'https://openmanager-vibe-v5.onrender.com']
+          ? ['https://openmanager-vibe-v5.vercel.app', 'https://openmanager-ai-engine.onrender.com']
           : ['http://localhost:3000'],
         methods: ['GET', 'POST'],
         credentials: true


### PR DESCRIPTION
## Summary
- update environment variable name from `AI_ENGINE_URL` to `FASTAPI_BASE_URL`
- default url now `https://openmanager-ai-engine.onrender.com`
- update docs, scripts, and source accordingly

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test:unit` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6840f17e43208325888dfe9f69bf6933