### PR TITLE
Fix domain references

### DIFF
--- a/scripts/test-warmup.sh
+++ b/scripts/test-warmup.sh
@@ -4,7 +4,7 @@ echo "🔥 AI 시스템 웜업 및 온/오프 테스트 시작..."
 echo "================================================"
 
 # Python 서비스 URL
-PYTHON_URL="https://openmanager-vibe-v5.onrender.com"
+PYTHON_URL="https://openmanager-ai-engine.onrender.com"
 LOCAL_URL="http://localhost:3000"
 
 echo ""

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -45,8 +45,8 @@ export interface AlertData {
 
 export const useWebSocket = (config: WebSocketConfig = {}) => {
   const {
-    url = process.env.NODE_ENV === 'production' 
-      ? 'https://openmanager-vibe-v5.onrender.com'
+    url = process.env.NODE_ENV === 'production'
+      ? 'https://openmanager-ai-engine.onrender.com'
       : 'http://localhost:3000',
     autoConnect = true,
     reconnectAttempts = 5,

--- a/src/services/websocket/WebSocketManager.ts
+++ b/src/services/websocket/WebSocketManager.ts
@@ -66,8 +66,8 @@ export class WebSocketManager {
   initialize(server: any): void {
     this.io = new SocketIOServer(server, {
       cors: {
-        origin: process.env.NODE_ENV === 'production' 
-          ? ['https://openmanager-vibe-v5.vercel.app', 'https://openmanager-vibe-v5.onrender.com']
+        origin: process.env.NODE_ENV === 'production'
+          ? ['https://openmanager-vibe-v5.vercel.app', 'https://openmanager-ai-engine.onrender.com']
           : ['http://localhost:3000'],
         methods: ['GET', 'POST'],
         credentials: true


### PR DESCRIPTION
## Summary
- update AI engine URL in test script
- sync default production WebSocket URLs

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6840f19107a88325b600aee7c68ede92