### PR TITLE
Update docs with FASTAPI_BASE_URL

### DIFF
--- a/docs/3_INSTALLATION_AND_SETUP.md
+++ b/docs/3_INSTALLATION_AND_SETUP.md
@@ -121,7 +121,7 @@ PORT=3001
 # AI 엔진 설정 (선택사항)
 PYTHON_PATH=python3
 AI_ENGINE_MODE=optimized
-AI_ENGINE_URL=https://your-python-service.onrender.com
+FASTAPI_BASE_URL=https://openmanager-ai-engine.onrender.com
 
 # 데이터베이스 설정 (선택사항)
 # Supabase 또는 기타 PostgreSQL
@@ -144,7 +144,7 @@ VERCEL_PLAN=hobby  # 또는 pro
 
 # AI 엔진 (프로덕션)
 AI_ENGINE_MODE=production
-AI_ENGINE_URL=https://your-production-ai-service.com
+FASTAPI_BASE_URL=https://openmanager-ai-engine.onrender.com
 
 # 보안 설정
 ADMIN_PIN=your_secure_pin

--- a/docs/4_AI_AGENT_GUIDE.md
+++ b/docs/4_AI_AGENT_GUIDE.md
@@ -802,7 +802,7 @@ curl http://localhost:3001/api/ai-agent/admin/metrics
 
 #### 일반적인 문제
 1. **Python 엔진 연결 실패**
-   - 환경 변수 `AI_ENGINE_URL` 확인
+   - 환경 변수 `FASTAPI_BASE_URL` 확인
    - 네트워크 연결 상태 확인
    - TypeScript 폴백으로 자동 전환됨
 

--- a/docs/6_TESTING_AND_DEPLOYMENT.md
+++ b/docs/6_TESTING_AND_DEPLOYMENT.md
@@ -326,7 +326,7 @@ describe('MCP Integration', () => {
 
   it('Python 엔진 실패 시 TypeScript 폴백이 작동한다', async () => {
     // Python 엔진 URL을 잘못된 값으로 설정
-    process.env.AI_ENGINE_URL = 'http://invalid-url:9999';
+    process.env.FASTAPI_BASE_URL = 'http://invalid-url:9999';
 
     const request = {
       query: 'CPU 분석',

--- a/docs/7_TROUBLESHOOTING.md
+++ b/docs/7_TROUBLESHOOTING.md
@@ -79,7 +79,7 @@ npm run clean:ports
 **해결 방법:**
 ```bash
 # 1. Python 엔진 연결 확인
-curl $AI_ENGINE_URL/health
+curl $FASTAPI_BASE_URL/health
 
 # 2. TypeScript 폴백 테스트
 curl http://localhost:3001/api/ai-agent/integrated


### PR DESCRIPTION
## Summary
- rename `AI_ENGINE_URL` to `FASTAPI_BASE_URL` in docs
- unify example URL to `https://openmanager-ai-engine.onrender.com`

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6840f198ebe88325914ba252a148d9cc