### PR TITLE
Update Python service references

### DIFF
--- a/docs/3_INSTALLATION_AND_SETUP.md
+++ b/docs/3_INSTALLATION_AND_SETUP.md
@@ -121,7 +121,7 @@ PORT=3001
 # AI 엔진 설정 (선택사항)
 PYTHON_PATH=python3
 AI_ENGINE_MODE=optimized
-AI_ENGINE_URL=https://your-python-service.onrender.com
+PYTHON_SERVICE_URL=https://openmanager-vibe-v5.onrender.com
 
 # 데이터베이스 설정 (선택사항)
 # Supabase 또는 기타 PostgreSQL
@@ -144,7 +144,7 @@ VERCEL_PLAN=hobby  # 또는 pro
 
 # AI 엔진 (프로덕션)
 AI_ENGINE_MODE=production
-AI_ENGINE_URL=https://your-production-ai-service.com
+PYTHON_SERVICE_URL=https://openmanager-vibe-v5.onrender.com
 
 # 보안 설정
 ADMIN_PIN=your_secure_pin

--- a/docs/4_AI_AGENT_GUIDE.md
+++ b/docs/4_AI_AGENT_GUIDE.md
@@ -802,7 +802,7 @@ curl http://localhost:3001/api/ai-agent/admin/metrics
 
 #### 일반적인 문제
 1. **Python 엔진 연결 실패**
-   - 환경 변수 `AI_ENGINE_URL` 확인
+   - 환경 변수 `PYTHON_SERVICE_URL` 확인
    - 네트워크 연결 상태 확인
    - TypeScript 폴백으로 자동 전환됨
 

--- a/docs/6_TESTING_AND_DEPLOYMENT.md
+++ b/docs/6_TESTING_AND_DEPLOYMENT.md
@@ -326,7 +326,7 @@ describe('MCP Integration', () => {
 
   it('Python 엔진 실패 시 TypeScript 폴백이 작동한다', async () => {
     // Python 엔진 URL을 잘못된 값으로 설정
-    process.env.AI_ENGINE_URL = 'http://invalid-url:9999';
+    process.env.PYTHON_SERVICE_URL = 'http://invalid-url:9999';
 
     const request = {
       query: 'CPU 분석',

--- a/docs/7_TROUBLESHOOTING.md
+++ b/docs/7_TROUBLESHOOTING.md
@@ -79,7 +79,7 @@ npm run clean:ports
 **해결 방법:**
 ```bash
 # 1. Python 엔진 연결 확인
-curl $AI_ENGINE_URL/health
+curl $PYTHON_SERVICE_URL/health
 
 # 2. TypeScript 폴백 테스트
 curl http://localhost:3001/api/ai-agent/integrated

--- a/scripts/test-warmup.sh
+++ b/scripts/test-warmup.sh
@@ -4,7 +4,7 @@ echo "🔥 AI 시스템 웜업 및 온/오프 테스트 시작..."
 echo "================================================"
 
 # Python 서비스 URL
-PYTHON_URL="https://openmanager-vibe-v5.onrender.com"
+PYTHON_URL="${PYTHON_SERVICE_URL:-https://openmanager-vibe-v5.onrender.com}"
 LOCAL_URL="http://localhost:3000"
 
 echo ""

--- a/src/app/api/v1/ai/unified/route.ts
+++ b/src/app/api/v1/ai/unified/route.ts
@@ -219,7 +219,9 @@ export async function POST(request: NextRequest) {
     let pythonAnalysis: any = null;
     if (body.options?.usePython && metrics) {
       try {
-        const pythonUrl = process.env.PYTHON_SERVICE_URL || 'https://openmanager-ai-python.onrender.com';
+        const pythonUrl =
+          process.env.PYTHON_SERVICE_URL ||
+          'https://openmanager-vibe-v5.onrender.com';
         const response = await fetch(`${pythonUrl}/analyze`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -503,7 +505,9 @@ function combineRecommendations(aiAnalysis: any, pythonAnalysis: any, mcpResults
 
 async function checkPythonService(): Promise<any> {
   try {
-    const pythonUrl = process.env.PYTHON_SERVICE_URL || 'https://openmanager-ai-python.onrender.com';
+    const pythonUrl =
+      process.env.PYTHON_SERVICE_URL ||
+      'https://openmanager-vibe-v5.onrender.com';
     const response = await fetch(`${pythonUrl}/health`, {
       method: 'GET',
       signal: AbortSignal.timeout(5000)

--- a/src/services/ai/RealAIProcessor.ts
+++ b/src/services/ai/RealAIProcessor.ts
@@ -81,8 +81,10 @@ export class RealAIProcessor {
   private enabledModels: string[] = [];
 
   private constructor() {
-    // Render Python 서버 URL (무료 tier)
-    this.pythonServiceUrl = process.env.PYTHON_SERVICE_URL || 'https://openmanager-ai-python.onrender.com';
+    // Python 분석 서버 URL
+    this.pythonServiceUrl =
+      process.env.PYTHON_SERVICE_URL ||
+      'https://openmanager-vibe-v5.onrender.com';
     
     // 사용 가능한 모델들 확인
     this.initializeModels();


### PR DESCRIPTION
## Summary
- point AI code to new Python service URL
- switch documentation to use `PYTHON_SERVICE_URL`
- allow example warmup script to read `PYTHON_SERVICE_URL`

## Testing
- `npm test --silent` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6840f1a3af6c83258edd71dddc404515