### PR TITLE
Add integration test for system start/stop

### DIFF
--- a/tests/integration/system-start-stop.test.ts
+++ b/tests/integration/system-start-stop.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { POST as startSystem } from '@/app/api/system/start/route';
+import { POST as stopSystem } from '@/app/api/system/stop/route';
+import { NextRequest } from 'next/server';
+import { systemStateManager } from '@/core/system/SystemStateManager';
+
+// 통합 테스트: 시스템 시작 및 중지 API
+
+describe('System start/stop API', () => {
+  beforeEach(async () => {
+    // 테스트 시작 전 엔진을 중지하여 초기 상태 보장
+    await systemStateManager.stopSimulation();
+  });
+
+  afterEach(async () => {
+    // 테스트 종료 후 엔진 중지
+    await systemStateManager.stopSimulation();
+  });
+
+  it('startSystem 호출 후 엔진이 실행되고 stopSystem 호출 후 중지된다', async () => {
+    const startReq = new NextRequest('http://localhost/api/system/start', {
+      method: 'POST',
+      body: JSON.stringify({ mode: 'fast' }),
+      headers: { 'Content-Type': 'application/json' }
+    });
+
+    const startRes = await startSystem(startReq);
+    const startData = await startRes.json();
+    expect(startData.success).toBe(true);
+    expect(systemStateManager.getSystemStatus().simulation.isRunning).toBe(true);
+
+    const stopReq = new NextRequest('http://localhost/api/system/stop', {
+      method: 'POST',
+    });
+    const stopRes = await stopSystem(stopReq);
+    const stopData = await stopRes.json();
+    expect(stopData.success).toBe(true);
+    expect(systemStateManager.getSystemStatus().simulation.isRunning).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,10 @@ export default defineConfig({
     setupFiles: ['./src/testing/setup.ts'],
     globals: true,
     css: true,
-    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    include: [
+      'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'tests/integration/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'
+    ],
     exclude: [
       'node_modules',
       'dist',


### PR DESCRIPTION
## Summary
- add vitest integration test for system start and stop APIs
- include integration tests in the default vitest config

## Testing
- `npm run test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6841153738688325b4b6ea7772bc222c