### PR TITLE
Add lint and test steps to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,6 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: npm run build 
+      - run: npm run lint
+      - run: npm run test
+      - run: npm run build


### PR DESCRIPTION
## Summary
- add `npm run lint` and `npm run test` to CI workflow to enforce basic checks

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6841153805dc8325b03f932fd5627e14