### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -12,4 +14,6 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: npm run build 
+      - run: npm run lint
+      - run: npm run test
+      - run: npm run build


### PR DESCRIPTION
## Summary
- run lint and tests before building
- stop jobs early if any fail

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_684116b0dc58832592c75dbb9bce4480