### PR TITLE
Implement Supabase timeseries backup

### DIFF
--- a/src/services/redisTimeSeriesService.test.ts
+++ b/src/services/redisTimeSeriesService.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { redisTimeSeriesService } from './redisTimeSeriesService';
+
+const samplePoint = {
+  timestamp: Date.now(),
+  server_id: 'test-server',
+  hostname: 'test-host',
+  environment: 'test',
+  role: 'web',
+  metrics: {
+    cpu_usage: 10,
+    memory_usage: 20,
+    disk_usage: 30,
+    network_in: 40,
+    network_out: 50,
+    response_time: 60,
+  },
+  status: 'ok',
+  alerts_count: 0
+};
+
+describe('redisTimeSeriesService.backupToSupabase', () => {
+  it('Supabase 클라이언트 미초기화 시 경고 로그를 출력해야 함', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await (redisTimeSeriesService as any).backupToSupabase([samplePoint]);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/src/services/redisTimeSeriesService.ts
+++ b/src/services/redisTimeSeriesService.ts
@@ -245,10 +245,13 @@ export class RedisTimeSeriesService {
    */
   private async backupToSupabase(points: TimeSeriesPoint[]): Promise<void> {
     try {
-      // Supabase 백업 로직 (실제 구현시 주석 해제)
-      /*
       const { supabase } = await import('../lib/supabase');
-      
+
+      if (!supabase) {
+        console.warn('⚠️ Supabase client not initialized. 백업을 건너뜁니다');
+        return;
+      }
+
       const backupData = points.map(point => ({
         server_id: point.server_id,
         timestamp: new Date(point.timestamp).toISOString(),
@@ -260,12 +263,15 @@ export class RedisTimeSeriesService {
         alerts_count: point.alerts_count
       }));
 
-      await supabase
+      const { error } = await supabase
         .from('server_metrics_timeseries')
         .insert(backupData);
-      */
-      
-      console.log(`💾 Supabase 백업 시뮬레이션: ${points.length}개 포인트`);
+
+      if (error) {
+        console.warn('⚠️ Supabase 백업 실패:', error);
+      } else {
+        console.log(`💾 Supabase 백업 완료: ${points.length}개 포인트`);
+      }
     } catch (error) {
       console.warn('⚠️ Supabase 백업 실패:', error);
     }


### PR DESCRIPTION
## Summary
- restore Supabase backup logic in `redisTimeSeriesService`
- utilize Supabase client with error handling
- add unit test verifying backup warning on missing client

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68411c9f1f608325ad59d8b4c65d4b6c