### PR TITLE
Initialize RealPrometheusCollector in RealServerDataGenerator

### DIFF
--- a/src/services/data-generator/RealServerDataGenerator.ts
+++ b/src/services/data-generator/RealServerDataGenerator.ts
@@ -122,9 +122,9 @@ export class RealServerDataGenerator {
   public async initialize(): Promise<void> {
     try {
       this.redis = await getRedisClient();
+      await realPrometheusCollector.initialize();
       console.log('✅ 실제 서버 데이터 생성기 초기화 완료');
-      
-      // 자동 생성 시작
+
       this.startAutoGeneration();
       
     } catch (error) {


### PR DESCRIPTION
## Summary
- initialize RealPrometheusCollector after redis client
- remove outdated comment

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68411c9fcd748325ac4c765e8d4e006a