### PR TITLE
Allow custom server counts for metric generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,15 @@ npm run analyze
 npm run benchmark:ai
 ```
 
+### **샘플 메트릭 데이터 생성**
+```bash
+# 기본 20대 서버 기준 데이터 생성
+npm run generate:metrics
+
+# 서버 수 지정 예시
+npm run generate:metrics -- --web 8 --api 8 --db 4 --cache 2 --worker 2
+```
+
 ---
 
 ## 📈 **성능 메트릭**


### PR DESCRIPTION
## Summary
- adjust generator comment to mention custom server count
- add server count parameters to `createServerConfigs`
- parse CLI flags/environment variables for custom counts
- log server count dynamically
- document metric generation with new options

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684126ea13a483259a07645d75892ad3