### PR TITLE
Update docs for MCP configuration

### DIFF
--- a/docs/9_MCP_ENGINE_REFERENCE.md
+++ b/docs/9_MCP_ENGINE_REFERENCE.md
@@ -3,13 +3,33 @@
 **버전**: v5.13.5  
 **최종 업데이트**: 2025-05-31  
 **MCP 버전**: 1.0.0  
-**핵심 기술**: Model Context Protocol + 하이브리드 AI 엔진  
+**핵심 기술**: Model Context Protocol + 하이브리드 AI 엔진
 
 ---
+
+### 🛠️ 기술 스택
+
+- Next.js API Routes (Node.js)
+- FastAPI (Render 호스팅)
+- Scikit-learn
+- Transformers.js
+- Redis
 
 ## 🎯 MCP 엔진 개요
 
 OpenManager v5의 **MCP(Model Context Protocol) 엔진**은 자연어 질의를 6개의 전문화된 도구로 자동 변환하여 지능형 서버 분석을 수행하는 핵심 시스템입니다. Python ML 엔진과 TypeScript 폴백을 통한 하이브리드 아키텍처로 99.9% 가용성을 보장합니다.
+
+### MCP 서버 구성
+- MCP 서버는 **Next.js API Routes**를 사용하여 `/api/mcp` 경로에서 동작합니다.
+- Node.js 20 환경에서 실행되며 Vercel SDK는 사용하지 않습니다.
+
+### 컨텍스트 사용 방식
+- `ContextManager`가 세션별 단기 메모리와 Redis 기반 장기 메모리를 결합합니다.
+- 클라이언트에서 전달된 `context` 정보는 우선적으로 병합되어 도구 선택에 활용됩니다.
+
+### Render 기반 Python 엔진 위치
+- Python ML 엔진은 Render의 `https://openmanager-ai-engine.onrender.com`에 배포되어 있습니다.
+- MCP 서버는 해당 주소로 HTTP POST 요청을 보내 분석 결과를 받아옵니다.
 
 ## 🏗️ MCP 아키텍처 상세
 

--- a/docs/AI_AGENT_ARCHITECTURE_SPECIFICATION.md
+++ b/docs/AI_AGENT_ARCHITECTURE_SPECIFICATION.md
@@ -1,10 +1,17 @@
 # 📘 OpenManager V5 - AI 에이전트 & 엔진 전체 아키텍처 설계
 
 > **최종 작성**: 2025-01-27  
-> **기반 기술**: Next.js 15 + TypeScript + Zustand + MCP Protocol  
+> **기반 기술**: Next.js 15 + TypeScript + Zustand + MCP Protocol
 > **설계 범위**: 프론트엔드 → 백엔드 → AI 엔진 → 상태 흐름 → 보안 제어
 
 ---
+
+### 🛠️ 기술 스택
+
+- Next.js 15 API Routes (Node.js)
+- FastAPI (Render 호스팅)
+- Scikit-learn, Transformers.js
+- Redis, Zustand
 
 ## 🎯 1. 전체 시스템 아키텍처 설계
 
@@ -444,8 +451,24 @@ class MetricsPredictor:
             metric_analysis = self._analyze_metrics_data(metrics)
             analysis_result.update(metric_analysis)
             
-        return analysis_result
+return analysis_result
 ```
+
+### 3.5 MCP 서버 구성
+
+- MCPProcessor는 **Next.js API Routes** 기반 `/api/mcp` 엔드포인트에서 실행됩니다.
+- Node.js 런타임에서 직접 동작하며 Vercel SDK는 사용하지 않습니다.
+- Python 엔진 주소는 `FASTAPI_BASE_URL` 환경변수로 관리됩니다.
+
+### 3.6 컨텍스트 사용 방식
+
+- `ContextManager`가 세션별 단기 메모리와 Redis 장기 메모리를 결합하여 컨텍스트를 제공합니다.
+- 프론트엔드에서 전달된 `context` 객체를 우선 적용한 후 서버 저장 컨텍스트와 병합합니다.
+
+### 3.7 Render 기반 Python 엔진 위치
+
+- Python ML 엔진은 Render의 `https://openmanager-ai-engine.onrender.com`에서 동작합니다.
+- MCPProcessor는 해당 주소로 HTTP POST 요청을 전송해 분석 결과를 가져옵니다.
 
 ---
 

--- a/docs/AI_ENGINE_SETUP.md
+++ b/docs/AI_ENGINE_SETUP.md
@@ -115,4 +115,29 @@ INTERNAL_AI_ENGINE_ENABLED=true
 INTERNAL_AI_ENGINE_FALLBACK=true
 PYTHON_SERVICE_WARMUP_ENABLED=true
 PYTHON_SERVICE_MAX_WARMUPS=4
-``` 
+```
+
+## MCP 서버 구성
+
+- MCP 서버는 **Next.js API Routes** 기반으로 동작하며 `/api/mcp`에서 요청을 처리합니다.
+- Node.js 20 런타임에서 실행되며 **Vercel SDK** 없이 Route Handler만 사용합니다.
+- Python 엔진 호출 주소는 `FASTAPI_BASE_URL` 환경변수로 지정합니다.
+
+## 컨텍스트 사용 방식
+
+- 모든 AI 요청은 `sessionId`를 기준으로 컨텍스트를 로드합니다.
+- 단기 컨텍스트는 메모리 Map으로 관리하고, 장기 컨텍스트는 Redis에 저장됩니다.
+- 프론트엔드에서 전달한 `context` 값과 병합해 MCP 서버에 전달합니다.
+
+## Render 기반 Python 엔진 위치
+
+- Python ML 엔진은 Render에서 운영되며 기본 URL은 `https://openmanager-ai-engine.onrender.com` 입니다.
+- 로컬 테스트 시 위 주소 대신 로컬 FastAPI 서버 주소를 `FASTAPI_BASE_URL`에 설정합니다.
+
+## 🛠️ 기술 스택
+
+- Next.js 15 API Routes (Node.js)
+- FastAPI
+- Scikit-learn
+- Transformers.js
+- Redis


### PR DESCRIPTION
## Summary
- document MCP 서버 구성과 컨텍스트 관리 방식
- 명시적으로 Render 기반 Python 엔진 위치를 추가
- 기술 스택 섹션에서 사용 오픈소스 라이브러리를 소개
- 강조점: Node 측은 Next.js API Routes 기반

## Testing
- `npm run test:unit` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68413bc4bedc8325908c47d849e1e7be