### PR TITLE
Update docs for optional AI API integration

### DIFF
--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -14,7 +14,9 @@ FASTAPI_BASE_URL="http://localhost:8000"
 FASTAPI_BASE_URL="https://your-python-ai-engine.render.com"
 ```
 
-### 2. AI 모델 API 키 (선택사항)
+### 2. AI 모델 API 키 (선택 사항)
+
+API 키를 입력하지 않으면 기본적으로 로컬 AI 엔진만 사용합니다.
 
 ```bash
 # OpenAI

--- a/docs/homepage-feature-cards.md
+++ b/docs/homepage-feature-cards.md
@@ -11,7 +11,7 @@ OpenManager V5 홈페이지에는 4개의 주요 기능을 소개하는 인터�
 
 #### 🛠️ 기술 스택
 - **MCP Protocol** 기반 AI 엔진과 `@modelcontextprotocol/sdk`
-- **OpenAI·Claude·Gemini** 통합 분석 지원
+- 필요 시 **OpenAI·Claude·Gemini API**를 연동해 추가 분석 가능
 - **Scikit‑learn**과 **Transformers.js** 연동
 - **Supabase** 및 **Redis** 실시간 데이터 활용
 

--- a/src/components/home/FeatureCardsGrid.tsx
+++ b/src/components/home/FeatureCardsGrid.tsx
@@ -19,7 +19,7 @@ const cardData = [
     detailedContent: {
       overview: 'MCP(Model Context Protocol) 표준을 활용한 차세대 AI 분석 엔진으로, 자연어 질의를 통해 복잡한 서버 분석을 수행합니다.',
       features: [
-        'OpenAI·Claude·Gemini 모델을 자동 선택해 분석합니다',
+        '필요 시 OpenAI·Claude·Gemini API를 연동해 추가 분석 가능합니다',
         'MCP Orchestrator가 statistical_analysis와 anomaly_detection을 조합합니다',
         'Python(Scikit-learn)과 Transformers.js 기반 AI 엔진을 연동합니다',
         'Supabase와 Redis 데이터를 실시간으로 참조합니다'


### PR DESCRIPTION
## Summary
- clarify optional use of OpenAI/Claude/Gemini APIs in homepage docs
- reflect same wording in homepage feature cards
- note that API keys are optional and local AI engine is used by default

## Testing
- `npm run test:unit` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68413bcba4948325a0b0512c77f66b7c