### PR TITLE
docs: clarify optional LLM integration

### DIFF
--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -17,13 +17,13 @@ FASTAPI_BASE_URL="https://your-python-ai-engine.render.com"
 ### 2. AI 모델 API 키 (선택사항)
 
 ```bash
-# OpenAI
+# OpenAI (선택 사항)
 OPENAI_API_KEY="sk-your-openai-api-key"
 
-# Anthropic Claude
+# Anthropic Claude (선택 사항)
 ANTHROPIC_API_KEY="your-anthropic-api-key"
 
-# Google Gemini
+# Google Gemini (선택 사항)
 GOOGLE_API_KEY="your-google-api-key"
 ```
 

--- a/docs/homepage-feature-cards.md
+++ b/docs/homepage-feature-cards.md
@@ -11,7 +11,7 @@ OpenManager V5 홈페이지에는 4개의 주요 기능을 소개하는 인터�
 
 #### 🛠️ 기술 스택
 - **MCP Protocol** 기반 AI 엔진과 `@modelcontextprotocol/sdk`
-- **OpenAI·Claude·Gemini** 통합 분석 지원
+- **Cursor AI**와 **Claude**로 개발, 필요 시 OpenAI/Gemini API 연동 가능
 - **Scikit‑learn**과 **Transformers.js** 연동
 - **Supabase** 및 **Redis** 실시간 데이터 활용
 

--- a/src/components/home/FeatureCardsGrid.tsx
+++ b/src/components/home/FeatureCardsGrid.tsx
@@ -19,7 +19,7 @@ const cardData = [
     detailedContent: {
       overview: 'MCP(Model Context Protocol) 표준을 활용한 차세대 AI 분석 엔진으로, 자연어 질의를 통해 복잡한 서버 분석을 수행합니다.',
       features: [
-        'OpenAI·Claude·Gemini 모델을 자동 선택해 분석합니다',
+        'Cursor AI 기반 분석, 필요하면 OpenAI·Claude·Gemini API를 선택적으로 사용합니다',
         'MCP Orchestrator가 statistical_analysis와 anomaly_detection을 조합합니다',
         'Python(Scikit-learn)과 Transformers.js 기반 AI 엔진을 연동합니다',
         'Supabase와 Redis 데이터를 실시간으로 참조합니다'

--- a/src/services/ai/RealAIProcessor.ts
+++ b/src/services/ai/RealAIProcessor.ts
@@ -3,11 +3,12 @@
  * 
  * 기술 스택:
  * - Vercel AI SDK (무료, 상업이용 가능)
- * - OpenAI GPT-3.5-turbo (무료 tier)
- * - Google Gemini (무료 tier)
- * - Anthropic Claude (무료 tier)
+ * - (옵션) OpenAI GPT-3.5-turbo (무료 tier)
+ * - (옵션) Google Gemini (무료 tier)
+ * - (옵션) Anthropic Claude (무료 tier)
  * - Redis 캐싱
  * - Render Python 서버 연동
+ * 기본적으로는 로컬 MCP 엔진만 사용합니다.
  */
 
 import { openai } from '@ai-sdk/openai';


### PR DESCRIPTION
## Summary
- update AI tech stack note on homepage feature cards
- refine AI model usage text on feature cards grid
- mark external LLM API keys as optional in setup docs
- mark external LLMs as optional in RealAIProcessor docs

## Testing
- `npm run test:unit` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68413bec11cc8325b0757e56495f78a3