### PR TITLE
Update mock dates to 2025

### DIFF
--- a/docs/CONSOLIDATED_DOCUMENTATION.md
+++ b/docs/CONSOLIDATED_DOCUMENTATION.md
@@ -398,7 +398,7 @@ chore: 빌드 프로세스 또는 보조 도구 변경
 - [Prometheus 문서](https://prometheus.io/docs)
 
 ### 🎓 학습 자료
-- [React 19 새로운 기능](https://react.dev/blog/2024/04/25/react-19)
+- [React 19 새로운 기능](https://react.dev/blog/2025/04/25/react-19)
 - [MCP 프로토콜 가이드](https://modelcontextprotocol.io)
 - [AI 에이전트 개발 패턴](https://docs.anthropic.com/claude/docs)
 

--- a/public/data/mock-servers.json
+++ b/public/data/mock-servers.json
@@ -12,7 +12,7 @@
     "network_out": 2048.7,
     "response_time": 120,
     "uptime": 360,
-    "last_updated": "2025-06-01T00:00:00Z"
+    "last_updated": "2025-06-15T00:00:00Z"
   },
   {
     "id": "api-server-02",
@@ -27,7 +27,7 @@
     "network_out": 1536.2,
     "response_time": 245,
     "uptime": 120,
-    "last_updated": "2025-06-01T00:00:00Z"
+    "last_updated": "2025-06-15T00:00:00Z"
   },
   {
     "id": "db-master-01",
@@ -42,7 +42,7 @@
     "network_out": 256.5,
     "response_time": 45,
     "uptime": 720,
-    "last_updated": "2025-06-01T00:00:00Z"
+    "last_updated": "2025-06-15T00:00:00Z"
   },
   {
     "id": "cache-redis-01",
@@ -57,6 +57,6 @@
     "network_out": 3072.4,
     "response_time": 2100,
     "uptime": 48,
-    "last_updated": "2025-06-01T00:00:00Z"
+    "last_updated": "2025-06-15T00:00:00Z"
   }
 ] 

--- a/src/components/ai/AIAgentAdminDashboard.tsx
+++ b/src/components/ai/AIAgentAdminDashboard.tsx
@@ -887,7 +887,7 @@ export default function AIAgentAdminDashboard() {
                   {[
                     {
                       id: 1,
-                      timestamp: '2025-06-19 14:32',
+                      timestamp: '2025-12-19 14:32',
                       question: 'CPU 사용률이 높은 서버를 찾아주세요',
                       feedback: 'positive',
                       comment: '정확한 서버 목록과 상세 정보를 제공해줘서 도움이 되었습니다.',
@@ -895,7 +895,7 @@ export default function AIAgentAdminDashboard() {
                     },
                     {
                       id: 2,
-                      timestamp: '2025-06-19 14:28',
+                      timestamp: '2025-12-19 14:28',
                       question: '네트워크 트래픽 분석 결과는?',
                       feedback: 'negative',
                       comment: '응답이 너무 늦고 정보가 부족합니다.',
@@ -903,7 +903,7 @@ export default function AIAgentAdminDashboard() {
                     },
                     {
                       id: 3,
-                      timestamp: '2025-06-19 14:25',
+                      timestamp: '2025-12-19 14:25',
                       question: '시스템 전체 상태를 요약해주세요',
                       feedback: 'positive',
                       comment: '종합적이고 이해하기 쉬운 요약이었습니다.',


### PR DESCRIPTION
## Summary
- update mock feedback dates in AIAgentAdminDashboard
- bump mock server `last_updated` field
- correct year in documentation link

## Testing
- `npm run test:unit` *(fails: expected false to be true, ...)*

------
https://chatgpt.com/codex/tasks/task_e_684141dc3f148325be4628127e594ecd