### PR TITLE
Fix counts object precedence in daily metrics script

### DIFF
--- a/scripts/generate-daily-metrics.ts
+++ b/scripts/generate-daily-metrics.ts
@@ -354,11 +354,11 @@ const main = async (): Promise<void> => {
     };
 
     const counts = {
-      web: getArgValue('web') ?? Number(process.env.WEB_COUNT) || undefined,
-      api: getArgValue('api') ?? Number(process.env.API_COUNT) || undefined,
-      db: getArgValue('db') ?? Number(process.env.DB_COUNT) || undefined,
-      cache: getArgValue('cache') ?? Number(process.env.CACHE_COUNT) || undefined,
-      worker: getArgValue('worker') ?? Number(process.env.WORKER_COUNT) || undefined
+      web: (getArgValue('web') ?? Number(process.env.WEB_COUNT)) || undefined,
+      api: (getArgValue('api') ?? Number(process.env.API_COUNT)) || undefined,
+      db: (getArgValue('db') ?? Number(process.env.DB_COUNT)) || undefined,
+      cache: (getArgValue('cache') ?? Number(process.env.CACHE_COUNT)) || undefined,
+      worker: (getArgValue('worker') ?? Number(process.env.WORKER_COUNT)) || undefined
     };
 
     const servers = createServerConfigs(counts);


### PR DESCRIPTION
## Summary
- fix the nullish coalescing precedence in `generate-daily-metrics.ts`

## Testing
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68414fec1f6483259bf53867bac94c1b