### PR TITLE
Add hybrid tensorflow integration test

### DIFF
--- a/tests/integration/hybrid-tensorflow.test.ts
+++ b/tests/integration/hybrid-tensorflow.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { hybridAIEngine } from '@/services/ai/hybrid-ai-engine';
+
+// 하이브리드 AI 엔진 TensorFlow 예측 테스트
+
+describe('Hybrid TensorFlow integration', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('processHybridQuery 호출 시 TensorFlow 예측과 MCP 액션을 반환한다', async () => {
+    // 내부 메서드 모킹
+    vi.spyOn(hybridAIEngine as any, 'initialize').mockResolvedValue(undefined);
+    vi.spyOn(hybridAIEngine as any, 'analyzeSmartQuery').mockResolvedValue({
+      originalQuery: 'cpu 예측',
+      intent: 'prediction',
+      keywords: ['cpu'],
+      requiredDocs: [],
+      mcpActions: [],
+      tensorflowModels: [],
+      isKorean: true,
+      useTransformers: false,
+      useVectorSearch: false,
+    });
+    vi.spyOn(hybridAIEngine as any, 'hybridDocumentSearch').mockResolvedValue([]);
+    vi.spyOn(hybridAIEngine as any, 'runHybridAnalysis').mockResolvedValue({
+      tensorflow: { ai_insights: ['mock insight'], prediction: {} },
+    });
+    vi.spyOn(hybridAIEngine as any, 'executeMCPActions').mockResolvedValue(['mock action']);
+    vi.spyOn(hybridAIEngine as any, 'generateHybridResponse').mockResolvedValue({
+      text: 'ok',
+      confidence: 0.9,
+      reasoning: [],
+    });
+    vi.spyOn(hybridAIEngine as any, 'updateEngineStats').mockReturnValue(undefined);
+
+    const result = await hybridAIEngine.processHybridQuery('cpu 예측');
+
+    expect(result.tensorflowPredictions).toBeDefined();
+    expect(result.mcpActions.length).toBeGreaterThan(0);
+    expect(result.tensorflowPredictions.ai_insights.length).toBeGreaterThan(0);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     css: true,
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'tests/integration/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
     ],
     exclude: [
       'node_modules',


### PR DESCRIPTION
## Summary
- run integration test coverage against TensorFlow path
- include integration tests in Vitest config

## Testing
- `npm run test:integration`

------
https://chatgpt.com/codex/tasks/task_e_6842757e40cc8325a510971d79665dd6