### PR TITLE
Add hybrid TensorFlow integration test and enable MCP intent classification test

### DIFF
--- a/tests/integration/hybrid-tensorflow.test.ts
+++ b/tests/integration/hybrid-tensorflow.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { hybridAIEngine } from '@/services/ai/hybrid-ai-engine';
+
+// 통합 테스트: HybridAIEngine의 TensorFlow 분석 결과 확인
+
+describe('HybridAIEngine TensorFlow integration', () => {
+  beforeAll(async () => {
+    await hybridAIEngine.initialize();
+    // TensorFlow 백그라운드 초기화 대기
+    await new Promise(res => setTimeout(res, 200));
+  });
+
+  it('processHybridQuery 호출 시 TensorFlow 분석 결과와 AI 인사이트가 생성된다', async () => {
+    const result = await hybridAIEngine.processHybridQuery('서버 장애를 예측해 줘');
+
+    expect(result.success).toBe(true);
+    expect(result.tensorflowPredictions).toBeDefined();
+    expect(result.reasoning.some(r => r.includes('TensorFlow'))).toBe(true);
+  });
+});

--- a/tests/integration/mcp-analysis.test.ts
+++ b/tests/integration/mcp-analysis.test.ts
@@ -1,13 +1,16 @@
 /**
  * 🎯 MCP 분석 통합 테스트
- * 
- * NOTE: UnifiedIntentClassifier 모듈이 제거되어 일시적으로 비활성화됨
  */
 
-import { describe, it } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import { IntentClassifier } from '@/services/ai/IntentClassifier';
 
-describe.skip('🎯 통합 Intent Classification 시스템 (비활성화)', () => {
-  it('테스트가 임시로 비활성화됨', () => {
-    // UnifiedIntentClassifier 모듈 제거로 인해 테스트가 비활성화되었습니다.
+describe('🎯 통합 Intent Classification 시스템', () => {
+  it('예측 관련 문구를 정확히 분류한다', async () => {
+    const classifier = new IntentClassifier();
+    const result = await classifier.classify('서버 성능을 예측해 줘');
+
+    expect(result.primary).toBe('server_performance_prediction');
+    expect(result.confidence).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- re-enable MCP integration test and verify IntentClassifier behavior
- add hybrid-ai TensorFlow integration test

## Testing
- `npm run test:integration` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68427630e7748325b835068cc54f0494