### PR TITLE
Prevent overlapping generation loops

### DIFF
--- a/src/services/collectors/RealPrometheusCollector.ts
+++ b/src/services/collectors/RealPrometheusCollector.ts
@@ -703,13 +703,21 @@ export class RealPrometheusCollector {
     if (this.isCollecting) return;
 
     this.isCollecting = true;
-    this.collectInterval = setInterval(async () => {
+
+    const loop = async () => {
+      if (!this.isCollecting) return;
       try {
         await this.collectMetrics();
       } catch (error) {
         console.error('❌ 자동 메트릭 수집 실패:', error);
+      } finally {
+        if (this.isCollecting) {
+          this.collectInterval = setTimeout(loop, this.config.collectInterval);
+        }
       }
-    }, this.config.collectInterval);
+    };
+
+    loop();
 
     console.log(`🔄 자동 메트릭 수집 시작 (${this.config.collectInterval}ms 간격)`);
   }
@@ -718,11 +726,11 @@ export class RealPrometheusCollector {
    * ⏹️ 자동 수집 중지
    */
   public stopAutoCollection(): void {
+    this.isCollecting = false;
     if (this.collectInterval) {
-      clearInterval(this.collectInterval);
+      clearTimeout(this.collectInterval);
       this.collectInterval = null;
     }
-    this.isCollecting = false;
     console.log('⏹️ 자동 메트릭 수집 중지');
   }
 

--- a/src/services/data-generator/RealServerDataGenerator.ts
+++ b/src/services/data-generator/RealServerDataGenerator.ts
@@ -506,13 +506,21 @@ export class RealServerDataGenerator {
     if (this.isGenerating) return;
 
     this.isGenerating = true;
-    this.generationInterval = setInterval(async () => {
+
+    const loop = async () => {
+      if (!this.isGenerating) return;
       try {
         await this.generateRealtimeData();
       } catch (error) {
         console.error('❌ 실시간 데이터 생성 실패:', error);
+      } finally {
+        if (this.isGenerating) {
+          this.generationInterval = setTimeout(loop, 5000);
+        }
       }
-    }, 5000); // 5초마다 업데이트
+    };
+
+    loop();
 
     console.log('🔄 실시간 서버 데이터 생성 시작');
   }
@@ -521,11 +529,11 @@ export class RealServerDataGenerator {
    * ⏹️ 자동 데이터 생성 중지
    */
   public stopAutoGeneration(): void {
+    this.isGenerating = false;
     if (this.generationInterval) {
-      clearInterval(this.generationInterval);
+      clearTimeout(this.generationInterval);
       this.generationInterval = null;
     }
-    this.isGenerating = false;
     console.log('⏹️ 실시간 서버 데이터 생성 중지');
   }
 

--- a/tests/integration/data-generation-loop.test.ts
+++ b/tests/integration/data-generation-loop.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RealServerDataGenerator } from '@/services/data-generator/RealServerDataGenerator';
+
+/**
+ * 실행 간격보다 generateRealtimeData 실행 시간이 긴 경우 중첩 실행이 발생하지 않는지 확인
+ */
+describe('RealServerDataGenerator 비동기 루프 동작', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (RealServerDataGenerator as any).instance = null;
+  });
+
+  afterEach(() => {
+    const generator = RealServerDataGenerator.getInstance();
+    generator.stopAutoGeneration();
+    vi.useRealTimers();
+  });
+
+  it('generateRealtimeData가 오래 걸려도 중복 호출되지 않는다', async () => {
+    const generator = RealServerDataGenerator.getInstance();
+    const spy = vi
+      .spyOn(generator as any, 'generateRealtimeData')
+      .mockImplementation(async () => {
+        await new Promise(res => setTimeout(res, 6000));
+      });
+
+    generator.startAutoGeneration();
+
+    // 첫 실행 중 5초 경과 - 중첩 호출 없어야 함
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // 첫 실행 종료 시점까지 진행
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // 이후 5초 대기 후 두 번째 실행
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid overlapping of real-time data generation
- ensure prometheus metrics collection runs sequentially
- add integration test for generation loop

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d6bd852883259d9cd6733bd7b551