### PR TITLE
Fix average calculations when no data

### DIFF
--- a/src/services/data-generator/RealServerDataGenerator.ts
+++ b/src/services/data-generator/RealServerDataGenerator.ts
@@ -781,14 +781,24 @@ export class RealServerDataGenerator {
         totalApplications: apps.length
       },
       health: {
-        averageScore: servers.reduce((sum, s) => sum + s.health.score, 0) / servers.length,
+        averageScore: servers.length
+          ? servers.reduce((sum, s) => sum + s.health.score, 0) / servers.length
+          : 0,
         criticalIssues: servers.reduce((sum, s) => sum + s.health.issues.length, 0),
-        availability: apps.reduce((sum, a) => sum + a.performance.availability, 0) / apps.length
+        availability: apps.length
+          ? apps.reduce((sum, a) => sum + a.performance.availability, 0) / apps.length
+          : 0
       },
       performance: {
-        avgCpu: servers.reduce((sum, s) => sum + s.metrics.cpu, 0) / servers.length,
-        avgMemory: servers.reduce((sum, s) => sum + s.metrics.memory, 0) / servers.length,
-        avgDisk: servers.reduce((sum, s) => sum + s.metrics.disk, 0) / servers.length,
+        avgCpu: servers.length
+          ? servers.reduce((sum, s) => sum + s.metrics.cpu, 0) / servers.length
+          : 0,
+        avgMemory: servers.length
+          ? servers.reduce((sum, s) => sum + s.metrics.memory, 0) / servers.length
+          : 0,
+        avgDisk: servers.length
+          ? servers.reduce((sum, s) => sum + s.metrics.disk, 0) / servers.length
+          : 0,
         totalRequests: servers.reduce((sum, s) => sum + s.metrics.requests, 0),
         totalErrors: servers.reduce((sum, s) => sum + s.metrics.errors, 0)
       },

--- a/tests/unit/dashboard-summary.test.ts
+++ b/tests/unit/dashboard-summary.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RealServerDataGenerator } from '@/services/data-generator/RealServerDataGenerator';
+
+// 서버나 애플리케이션이 없을 때 평균값이 0으로 처리되는지 확인
+
+describe('RealServerDataGenerator.getDashboardSummary', () => {
+  it('서버가 없을 경우 NaN이 아닌 0을 반환한다', () => {
+    const generator = RealServerDataGenerator.getInstance();
+
+    // 서버와 애플리케이션 리스트를 빈 배열로 모킹
+    vi.spyOn(generator, 'getAllServers').mockReturnValue([]);
+    vi.spyOn(generator, 'getAllClusters').mockReturnValue([]);
+    vi.spyOn(generator, 'getAllApplications').mockReturnValue([]);
+
+    const summary = generator.getDashboardSummary();
+
+    expect(summary.health.averageScore).toBe(0);
+    expect(summary.health.availability).toBe(0);
+    expect(summary.performance.avgCpu).toBe(0);
+    expect(summary.performance.avgMemory).toBe(0);
+    expect(summary.performance.avgDisk).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid NaN in `getDashboardSummary` by checking array lengths
- add unit test for empty server/app data

## Testing
- `npm run test:unit` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6842d6c2d1fc8325ae2c71df3bfac1b0