### PR TITLE
Fix auto scheduling loops

### DIFF
--- a/src/services/collectors/RealPrometheusCollector.ts
+++ b/src/services/collectors/RealPrometheusCollector.ts
@@ -703,14 +703,19 @@ export class RealPrometheusCollector {
     if (this.isCollecting) return;
 
     this.isCollecting = true;
-    this.collectInterval = setInterval(async () => {
+    const runCollection = async () => {
       try {
         await this.collectMetrics();
       } catch (error) {
         console.error('❌ 자동 메트릭 수집 실패:', error);
       }
-    }, this.config.collectInterval);
 
+      if (this.isCollecting) {
+        this.collectInterval = setTimeout(runCollection, this.config.collectInterval);
+      }
+    };
+
+    runCollection();
     console.log(`🔄 자동 메트릭 수집 시작 (${this.config.collectInterval}ms 간격)`);
   }
 
@@ -719,7 +724,7 @@ export class RealPrometheusCollector {
    */
   public stopAutoCollection(): void {
     if (this.collectInterval) {
-      clearInterval(this.collectInterval);
+      clearTimeout(this.collectInterval);
       this.collectInterval = null;
     }
     this.isCollecting = false;

--- a/src/services/data-generator/RealServerDataGenerator.ts
+++ b/src/services/data-generator/RealServerDataGenerator.ts
@@ -506,14 +506,19 @@ export class RealServerDataGenerator {
     if (this.isGenerating) return;
 
     this.isGenerating = true;
-    this.generationInterval = setInterval(async () => {
+    const runGeneration = async () => {
       try {
         await this.generateRealtimeData();
       } catch (error) {
         console.error('❌ 실시간 데이터 생성 실패:', error);
       }
-    }, 5000); // 5초마다 업데이트
 
+      if (this.isGenerating) {
+        this.generationInterval = setTimeout(runGeneration, 5000); // 5초 간격
+      }
+    };
+
+    runGeneration();
     console.log('🔄 실시간 서버 데이터 생성 시작');
   }
 
@@ -522,7 +527,7 @@ export class RealServerDataGenerator {
    */
   public stopAutoGeneration(): void {
     if (this.generationInterval) {
-      clearInterval(this.generationInterval);
+      clearTimeout(this.generationInterval);
       this.generationInterval = null;
     }
     this.isGenerating = false;

--- a/tests/integration/auto-schedule.test.ts
+++ b/tests/integration/auto-schedule.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RealServerDataGenerator } from '@/services/data-generator/RealServerDataGenerator';
+import { RealPrometheusCollector } from '@/services/collectors/RealPrometheusCollector';
+
+// 자동 실행 스케줄 중복 호출 방지 테스트
+
+describe('자동 실행 스케줄', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // 싱글톤 초기화 리셋
+    (RealServerDataGenerator as any).instance = null;
+    (RealPrometheusCollector as any).instance = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('startAutoGeneration이 이전 작업 완료 후 다음 호출을 예약한다', async () => {
+    const generator = RealServerDataGenerator.getInstance();
+    const spy = vi
+      .spyOn(generator as any, 'generateRealtimeData')
+      .mockImplementation(() => new Promise(res => setTimeout(res, 7000)));
+
+    generator.startAutoGeneration();
+
+    await vi.advanceTimersByTimeAsync(20000);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    generator.stopAutoGeneration();
+  });
+
+  it('startAutoCollection이 이전 작업 완료 후 다음 호출을 예약한다', async () => {
+    const collector = RealPrometheusCollector.getInstance({ collectInterval: 5000 });
+    const spy = vi
+      .spyOn(collector as any, 'collectMetrics')
+      .mockImplementation(() => new Promise(res => setTimeout(res, 7000)));
+
+    collector.startAutoCollection();
+
+    await vi.advanceTimersByTimeAsync(20000);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    collector.stopAutoCollection();
+  });
+});


### PR DESCRIPTION
## Summary
- use recursive `setTimeout` loops so each auto task schedules after previous run
- stop methods now `clearTimeout`
- add tests to ensure no overlapping execution

## Testing
- `npm run test:unit` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6842d800eae48325a9bbfa063b84954a