### PR TITLE
Fix dashboard averages when no servers

### DIFF
--- a/src/services/data-generator/RealServerDataGenerator.ts
+++ b/src/services/data-generator/RealServerDataGenerator.ts
@@ -772,6 +772,8 @@ export class RealServerDataGenerator {
     const servers = this.getAllServers();
     const clusters = this.getAllClusters();
     const apps = this.getAllApplications();
+    const serverCount = servers.length;
+    const appCount = apps.length;
 
     return {
       overview: {
@@ -781,14 +783,23 @@ export class RealServerDataGenerator {
         totalApplications: apps.length
       },
       health: {
-        averageScore: servers.reduce((sum, s) => sum + s.health.score, 0) / servers.length,
+        averageScore:
+          serverCount > 0
+            ? servers.reduce((sum, s) => sum + s.health.score, 0) / serverCount
+            : 0,
         criticalIssues: servers.reduce((sum, s) => sum + s.health.issues.length, 0),
-        availability: apps.reduce((sum, a) => sum + a.performance.availability, 0) / apps.length
+        availability:
+          appCount > 0
+            ? apps.reduce((sum, a) => sum + a.performance.availability, 0) / appCount
+            : 0
       },
       performance: {
-        avgCpu: servers.reduce((sum, s) => sum + s.metrics.cpu, 0) / servers.length,
-        avgMemory: servers.reduce((sum, s) => sum + s.metrics.memory, 0) / servers.length,
-        avgDisk: servers.reduce((sum, s) => sum + s.metrics.disk, 0) / servers.length,
+        avgCpu:
+          serverCount > 0 ? servers.reduce((sum, s) => sum + s.metrics.cpu, 0) / serverCount : 0,
+        avgMemory:
+          serverCount > 0 ? servers.reduce((sum, s) => sum + s.metrics.memory, 0) / serverCount : 0,
+        avgDisk:
+          serverCount > 0 ? servers.reduce((sum, s) => sum + s.metrics.disk, 0) / serverCount : 0,
         totalRequests: servers.reduce((sum, s) => sum + s.metrics.requests, 0),
         totalErrors: servers.reduce((sum, s) => sum + s.metrics.errors, 0)
       },

--- a/tests/unit/getDashboardSummary.test.ts
+++ b/tests/unit/getDashboardSummary.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { realServerDataGenerator } from '@/services/data-generator/RealServerDataGenerator';
+
+describe('getDashboardSummary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('서버가 없는 경우 NaN을 반환하지 않는다', () => {
+    vi.spyOn(realServerDataGenerator, 'getAllServers').mockReturnValue([]);
+    vi.spyOn(realServerDataGenerator, 'getAllClusters').mockReturnValue([]);
+    vi.spyOn(realServerDataGenerator, 'getAllApplications').mockReturnValue([]);
+
+    const summary = realServerDataGenerator.getDashboardSummary();
+
+    expect(Number.isNaN(summary.health.averageScore)).toBe(false);
+    expect(Number.isNaN(summary.performance.avgCpu)).toBe(false);
+    expect(summary.health.averageScore).toBe(0);
+    expect(summary.performance.avgCpu).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid NaN in `getDashboardSummary` by returning 0 when no server or app exists
- add unit test covering empty server list

## Testing
- `npm run test:unit` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6842dc3932188325a53453cf71abe9c4