### PR TITLE
Update TechStackAnalyzer aliases

### DIFF
--- a/src/utils/TechStackAnalyzer.ts
+++ b/src/utils/TechStackAnalyzer.ts
@@ -337,6 +337,12 @@ const TECH_DATABASE: Record<string, Omit<TechItem, 'usage'>> = {
     description: 'Anthropic의 대화형 AI 어시스턴트',
     importance: 'high'
   },
+  'claude-sonnet': {
+    name: 'Claude 3 Sonnet',
+    category: 'ai-development',
+    description: 'Anthropic Claude 3 패밀리 중 Sonnet 버전',
+    importance: 'high'
+  },
   'auto-doc-generator.js': {
     name: 'Auto Doc Generator',
     category: 'ai-development',
@@ -460,11 +466,16 @@ function normalizeTechName(tech: string): string {
     'tailwind': 'tailwindcss',
     'react-query': '@tanstack/react-query',
     'mcp': '@modelcontextprotocol/server-filesystem',
+    'mcp sdk': '@modelcontextprotocol/server-filesystem',
     'sklearn': 'scikit-learn',
     'tf.js': '@tensorflow/tfjs',
     'socketio': 'socket.io',
     'faker': '@faker-js/faker',
-    'playwright': '@playwright/test'
+    'playwright': '@playwright/test',
+    'cursor': 'cursor-ai',
+    'cursorai': 'cursor-ai',
+    'cursor ai': 'cursor-ai',
+    'claude sonnet': 'claude'
   };
 
   return normalizeMap[tech] || tech;


### PR DESCRIPTION
## Summary
- add claude-sonnet entry to tech database
- map cursor and claude sonnet aliases to existing names

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test:unit` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68431a7050788325837b826a17b6bfa3