### PR TITLE
Implement context bundle management features

### DIFF
--- a/src/app/api/admin/context-manager/route.ts
+++ b/src/app/api/admin/context-manager/route.ts
@@ -185,8 +185,9 @@ export async function POST(request: NextRequest) {
           }, { status: 403 });
         }
 
-        // TODO: 번들 업로드 로직 구현
-        const uploaded = true; // 임시로 true 반환
+        const uploaded = await ContextLoader
+          .getInstance()
+          .uploadContextBundle(bundleType, bundleData, clientId);
 
         if (uploaded) {
           return NextResponse.json({
@@ -218,7 +219,7 @@ export async function POST(request: NextRequest) {
 
       case 'invalidate-cache':
         // 컨텍스트 캐시 무효화
-        // TODO: 캐시 무효화 로직 구현
+        ContextLoader.getInstance().invalidateCache();
         
         return NextResponse.json({
           success: true,
@@ -253,14 +254,22 @@ export async function PUT(request: NextRequest) {
       case 'update-bundle-metadata':
         // 번들 메타데이터 업데이트
         const { bundleType, clientId, metadata } = params;
-        
-        // TODO: 번들 메타데이터 업데이트 로직 구현
-        
+
+        const metadataUpdated = await ContextLoader
+          .getInstance()
+          .updateBundleMetadata(bundleType, metadata, clientId);
+
+        if (metadataUpdated) {
+          return NextResponse.json({
+            success: true,
+            message: '번들 메타데이터가 업데이트되었습니다.',
+            data: { bundleType, clientId, metadata }
+          });
+        }
         return NextResponse.json({
-          success: true,
-          message: '번들 메타데이터가 업데이트되었습니다.',
-          data: { bundleType, clientId, metadata }
-        });
+          success: false,
+          error: '메타데이터 업데이트에 실패했습니다.'
+        }, { status: 500 });
 
       default:
         return NextResponse.json({
@@ -322,13 +331,21 @@ export async function DELETE(request: NextRequest) {
           }, { status: 403 });
         }
 
-        // TODO: 번들 삭제 로직 구현
-        
+        const deleted = await ContextLoader
+          .getInstance()
+          .deleteContextBundle(bundleType, clientId);
+
+        if (deleted) {
+          return NextResponse.json({
+            success: true,
+            message: `${bundleType} 번들이 삭제되었습니다.`,
+            data: { bundleType, clientId }
+          });
+        }
         return NextResponse.json({
-          success: true,
-          message: `${bundleType} 번들이 삭제되었습니다.`,
-          data: { bundleType, clientId }
-        });
+          success: false,
+          error: '번들 삭제에 실패했습니다.'
+        }, { status: 500 });
 
       default:
         return NextResponse.json({

--- a/src/modules/mcp/ContextLoader.ts
+++ b/src/modules/mcp/ContextLoader.ts
@@ -293,6 +293,63 @@ export class ContextLoader {
   }
 
   /**
+   * 번들 메타데이터 업데이트 (관리자 전용)
+   */
+  async updateBundleMetadata(
+    bundleType: 'base' | 'advanced' | 'custom',
+    metadata: Record<string, any>,
+    clientId?: string
+  ): Promise<boolean> {
+    try {
+      const metaPath = clientId && bundleType === 'custom'
+        ? path.join(this.documentsPath, bundleType, clientId, 'metadata.json')
+        : path.join(this.documentsPath, bundleType, 'metadata.json');
+
+      if (!fs.existsSync(path.dirname(metaPath))) {
+        console.warn(`[ContextLoader] 메타데이터 경로가 존재하지 않습니다: ${metaPath}`);
+        return false;
+      }
+
+      fs.writeFileSync(metaPath, JSON.stringify(metadata, null, 2), 'utf-8');
+      this.invalidateCache();
+      console.log(`✅ [ContextLoader] 번들 메타데이터 업데이트 완료: ${bundleType}${clientId ? `-${clientId}` : ''}`);
+      return true;
+
+    } catch (error) {
+      console.error(`❌ [ContextLoader] 번들 메타데이터 업데이트 실패:`, error);
+      return false;
+    }
+  }
+
+  /**
+   * 컨텍스트 번들 삭제 (관리자 전용)
+   */
+  async deleteContextBundle(
+    bundleType: 'base' | 'advanced' | 'custom',
+    clientId?: string
+  ): Promise<boolean> {
+    try {
+      const targetPath = clientId && bundleType === 'custom'
+        ? path.join(this.documentsPath, bundleType, clientId)
+        : path.join(this.documentsPath, bundleType);
+
+      if (!fs.existsSync(targetPath)) {
+        console.warn(`[ContextLoader] 삭제할 번들이 존재하지 않습니다: ${targetPath}`);
+        return false;
+      }
+
+      fs.rmSync(targetPath, { recursive: true, force: true });
+      this.invalidateCache();
+      console.log(`🗑️ [ContextLoader] 번들 삭제 완료: ${bundleType}${clientId ? `-${clientId}` : ''}`);
+      return true;
+
+    } catch (error) {
+      console.error(`❌ [ContextLoader] 번들 삭제 실패:`, error);
+      return false;
+    }
+  }
+
+  /**
    * 백업 생성
    */
   private async createBackup(sourcePath: string): Promise<void> {

--- a/tests/unit/context-manager-api.test.ts
+++ b/tests/unit/context-manager-api.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { POST, PUT, DELETE } from '@/app/api/admin/context-manager/route';
+import { ContextLoader } from '@/modules/mcp/ContextLoader';
+import { NextRequest } from 'next/server';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Admin Context Manager API', () => {
+  it('upload-bundle 호출 시 ContextLoader.uploadContextBundle이 실행된다', async () => {
+    const loader = ContextLoader.getInstance();
+    const spy = vi.spyOn(loader, 'uploadContextBundle').mockResolvedValue(true);
+
+    const req = new NextRequest('http://localhost/api/admin/context-manager', {
+      method: 'POST',
+      body: JSON.stringify({
+        action: 'upload-bundle',
+        bundleType: 'advanced',
+        bundleData: { documents: { markdown: {}, patterns: {} } }
+      }),
+      headers: { 'Content-Type': 'application/json' }
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(spy).toHaveBeenCalledWith('advanced', { documents: { markdown: {}, patterns: {} } }, undefined);
+    expect(data.success).toBe(true);
+  });
+
+  it('invalidate-cache 호출 시 ContextLoader.invalidateCache가 실행된다', async () => {
+    const loader = ContextLoader.getInstance();
+    const spy = vi.spyOn(loader, 'invalidateCache');
+
+    const req = new NextRequest('http://localhost/api/admin/context-manager', {
+      method: 'POST',
+      body: JSON.stringify({ action: 'invalidate-cache' }),
+      headers: { 'Content-Type': 'application/json' }
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(spy).toHaveBeenCalled();
+    expect(data.success).toBe(true);
+  });
+
+  it('update-bundle-metadata 호출 시 ContextLoader.updateBundleMetadata가 실행된다', async () => {
+    const loader = ContextLoader.getInstance();
+    const spy = vi.spyOn(loader, 'updateBundleMetadata').mockResolvedValue(true);
+
+    const req = new NextRequest('http://localhost/api/admin/context-manager', {
+      method: 'PUT',
+      body: JSON.stringify({
+        action: 'update-bundle-metadata',
+        bundleType: 'advanced',
+        metadata: { version: '1.1.0' }
+      }),
+      headers: { 'Content-Type': 'application/json' }
+    });
+
+    const res = await PUT(req);
+    const data = await res.json();
+
+    expect(spy).toHaveBeenCalledWith('advanced', { version: '1.1.0' }, undefined);
+    expect(data.success).toBe(true);
+  });
+
+  it('delete-bundle 호출 시 ContextLoader.deleteContextBundle이 실행된다', async () => {
+    const loader = ContextLoader.getInstance();
+    const spy = vi.spyOn(loader, 'deleteContextBundle').mockResolvedValue(true);
+
+    const req = new NextRequest('http://localhost/api/admin/context-manager?action=delete-bundle&bundleType=advanced', {
+      method: 'DELETE'
+    });
+
+    const res = await DELETE(req);
+    const data = await res.json();
+
+    expect(spy).toHaveBeenCalledWith('advanced', null as any);
+    expect(data.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- enable bundle uploads, cache invalidation, metadata updates and deletion
- add helper methods in `ContextLoader`
- test new admin context manager API actions

## Testing
- `npm run test:unit` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_684617d983ec832597efad04a9fb107c