### PR TITLE
Fix edge runtime process checks

### DIFF
--- a/src/app/api/ai/hybrid/route.ts
+++ b/src/app/api/ai/hybrid/route.ts
@@ -186,8 +186,14 @@ export async function GET(request: NextRequest) {
         ],
         healthCheck: {
           timestamp: new Date().toISOString(),
-          uptime: process.uptime(),
-          memory: process.memoryUsage()
+          uptime:
+            typeof process !== 'undefined' && typeof process.uptime === 'function'
+              ? process.uptime()
+              : 0,
+          memory:
+            typeof process !== 'undefined' && typeof process.memoryUsage === 'function'
+              ? process.memoryUsage()
+              : { rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0 }
         }
       }
     });

--- a/src/app/api/v1/route.ts
+++ b/src/app/api/v1/route.ts
@@ -195,8 +195,14 @@ async function getSystemHealth() {
         realTimeMonitoring: true
       },
 
-      uptime: process.uptime(),
-      memoryUsage: process.memoryUsage()
+      uptime:
+        typeof process !== 'undefined' && typeof process.uptime === 'function'
+          ? process.uptime()
+          : 0,
+      memoryUsage:
+        typeof process !== 'undefined' && typeof process.memoryUsage === 'function'
+          ? process.memoryUsage()
+          : { rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0 }
     });
 
   } catch (error: any) {
@@ -236,12 +242,24 @@ async function getSystemStats() {
         },
         caching: cacheStats,
         memory: {
-          used: process.memoryUsage().heapUsed,
-          total: process.memoryUsage().heapTotal,
-          external: process.memoryUsage().external
+          used:
+            typeof process !== 'undefined' && typeof process.memoryUsage === 'function'
+              ? process.memoryUsage().heapUsed
+              : 0,
+          total:
+            typeof process !== 'undefined' && typeof process.memoryUsage === 'function'
+              ? process.memoryUsage().heapTotal
+              : 0,
+          external:
+            typeof process !== 'undefined' && typeof process.memoryUsage === 'function'
+              ? process.memoryUsage().external
+              : 0
         },
         system: {
-          uptime: process.uptime(),
+          uptime:
+            typeof process !== 'undefined' && typeof process.uptime === 'function'
+              ? process.uptime()
+              : 0,
           platform: process.platform,
           node_version: process.version
         }

--- a/src/core/ai/UnifiedAIEngine.ts
+++ b/src/core/ai/UnifiedAIEngine.ts
@@ -555,8 +555,11 @@ export class UnifiedAIEngine {
       // MCP 클라이언트 상태
       const mcpStatus = this.mcpClient ? this.mcpClient.getConnectionStatus() : {};
       
-      // 메모리 사용량
-      const memoryUsage = process.memoryUsage();
+      // 메모리 사용량 (Edge 환경 대비)
+      const memoryUsage =
+        typeof process !== 'undefined' && typeof process.memoryUsage === 'function'
+          ? process.memoryUsage()
+          : { heapUsed: 0, heapTotal: 0, external: 0, rss: 0, arrayBuffers: 0 };
       
       return {
         redis: redisStatus,
@@ -566,7 +569,10 @@ export class UnifiedAIEngine {
           heapTotal: Math.round(memoryUsage.heapTotal / 1024 / 1024),
           external: Math.round(memoryUsage.external / 1024 / 1024)
         },
-        uptime: Math.round(process.uptime()),
+        uptime:
+          typeof process !== 'undefined' && typeof process.uptime === 'function'
+            ? Math.round(process.uptime())
+            : 0,
         timestamp: new Date().toISOString(),
         status: 'healthy'
       };

--- a/src/modules/ai-agent/core/AIAgentEngine.ts
+++ b/src/modules/ai-agent/core/AIAgentEngine.ts
@@ -362,12 +362,21 @@ export class AIAgentEngine {
    * 엔진 상태 확인
    */
   getEngineStatus() {
+    const uptime =
+      typeof process !== 'undefined' && typeof process.uptime === 'function'
+        ? process.uptime()
+        : 0;
+    const memory =
+      typeof process !== 'undefined' && typeof process.memoryUsage === 'function'
+        ? process.memoryUsage()
+        : { rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0 };
+
     return {
       isInitialized: this.isInitialized,
       config: this.config,
       version: '1.0.0',
-      uptime: process.uptime(),
-      memory: process.memoryUsage()
+      uptime,
+      memory
     };
   }
 

--- a/src/modules/ai-agent/core/AdminLogger.ts
+++ b/src/modules/ai-agent/core/AdminLogger.ts
@@ -270,7 +270,10 @@ export class AdminLogger {
     return {
       totalInteractions: this.interactionLogs.length,
       totalErrors: this.errorLogs.length,
-      uptime: process.uptime ? process.uptime() * 1000 : 0,
+      uptime:
+        typeof process !== 'undefined' && typeof process.uptime === 'function'
+          ? process.uptime() * 1000
+          : 0,
       
       recent24h: {
         interactions: recent24hLogs.length,
@@ -302,7 +305,10 @@ export class AdminLogger {
         averageResponseTime: Math.round(avgResponseTime),
         p95ResponseTime: Math.round(p95ResponseTime),
         cacheHitRate: Math.round(cacheHitRate * 100) / 100,
-        memoryUsage: process.memoryUsage ? process.memoryUsage().heapUsed / 1024 / 1024 : 0
+        memoryUsage:
+          typeof process !== 'undefined' && typeof process.memoryUsage === 'function'
+            ? process.memoryUsage().heapUsed / 1024 / 1024
+            : 0
       }
     };
   }
@@ -519,7 +525,10 @@ export class AdminLogger {
       advancedModeRequests: advancedLogs.length,
       averageThinkingTime: Math.round(avgThinkingTime),
       cacheHitRate: Math.round(cacheHitRate * 100) / 100,
-      memoryUsage: process.memoryUsage ? process.memoryUsage().heapUsed / 1024 / 1024 : 0,
+      memoryUsage:
+        typeof process !== 'undefined' && typeof process.memoryUsage === 'function'
+          ? process.memoryUsage().heapUsed / 1024 / 1024
+          : 0,
       activeSessions: 0, // 실제 세션 수로 업데이트 필요
       powerModeDistribution: {} // 실제 전원 모드 분포로 업데이트 필요
     });

--- a/src/services/websocket/WebSocketManager.ts
+++ b/src/services/websocket/WebSocketManager.ts
@@ -430,7 +430,10 @@ export class WebSocketManager {
     return {
       totalConnections: this.clients.size,
       activeStreams: this.streams.size,
-      uptime: process.uptime(),
+      uptime:
+        typeof process !== 'undefined' && typeof process.uptime === 'function'
+          ? process.uptime()
+          : 0,
     };
   }
 

--- a/tests/unit/edge-runtime.test.ts
+++ b/tests/unit/edge-runtime.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { aiAgentEngine } from '@/modules/ai-agent/core/AIAgentEngine';
+import { GET as hybridGet } from '@/app/api/ai/hybrid/route';
+import { createMockNextRequest } from '@/testing/setup';
+
+// Edge runtime 호환성 테스트
+
+describe('Edge runtime compatibility', () => {
+  let originalProcess: any;
+
+  beforeAll(() => {
+    // process 객체가 없는 환경을 시뮬레이션
+    originalProcess = (globalThis as any).process;
+    (globalThis as any).process = undefined;
+  });
+
+  afterAll(() => {
+    // 원래 process 객체 복원
+    (globalThis as any).process = originalProcess;
+  });
+
+  it('AIAgentEngine.getEngineStatus 호출 시 오류가 발생하지 않는다', () => {
+    const status = aiAgentEngine.getEngineStatus();
+    expect(status.uptime).toBe(0);
+    expect(status.memory).toBeDefined();
+  });
+
+  it('Hybrid AI API GET 호출이 정상 동작한다', async () => {
+    const req = createMockNextRequest('http://localhost/api/ai/hybrid');
+    const res = await hybridGet(req as any);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.data.healthCheck.uptime).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- handle undefined `process` in engine status helpers
- ensure WebSocket manager and API routes work without Node `process`
- add unit test for Edge runtime environment

## Testing
- `npm run lint` *(fails: require() style import)*
- `npm run test:unit` *(failed: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_684617de485c8325b3629607ea91c789