### PR TITLE
Update version to 5.41.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openmanager-vibe-v5",
-  "version": "5.40.3",
+  "version": "5.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openmanager-vibe-v5",
-      "version": "5.40.3",
+      "version": "5.41.0",
       "hasInstallScript": true,
       "dependencies": {
         "@faker-js/faker": "^9.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmanager-vibe-v5",
-  "version": "5.40.3",
+  "version": "5.41.0",
   "description": "🚀 OpenManager AI v5.21.0 - AI 분석과 오토스케일링 완전 분리로 추론 안정성과 운영 시뮬 유연성을 동시에 확보한 차세대 서버 모니터링 시스템. 고정된 8개 AI 분석 타겟으로 일관된 추론을 보장하고, 8-30대 동적 서버 풀로 현실적인 스케일링 시뮬레이션을 제공합니다.",
   "private": true,
   "keywords": [


### PR DESCRIPTION
## Summary
- bump package version to 5.41.0
- update lock file to match

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461b48d4f883258355d6af5c390aab