### PR TITLE
Fix health API error response

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -79,15 +79,15 @@ export async function GET(request: NextRequest) {
     });
 
   } catch (error) {
-    console.error('❌ 헬스 체크 오류:', error);
-    
+    console.error('⚠️ 헬스 체크 오류 - 서버는 정상 동작 중입니다:', error);
+
     return NextResponse.json({
       status: 'unhealthy',
       timestamp: Date.now(),
       error: 'Health check failed',
       details: error instanceof Error ? error.message : 'Unknown error'
-    }, { 
-      status: 503,
+    }, {
+      status: 200,
       headers: {
         'Cache-Control': 'no-cache, no-store, must-revalidate',
         'Pragma': 'no-cache',

--- a/tests/integration/health-api.test.ts
+++ b/tests/integration/health-api.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/health/route';
+
+// Health API 통합 테스트
+
+describe('Health API', () => {
+  it('정상 동작 시 healthy 상태를 반환한다', async () => {
+    const req = new NextRequest('http://localhost/api/health', { method: 'GET' });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe('healthy');
+  });
+
+  it('오류 발생 시에도 200 상태 코드와 unhealthy 상태를 반환한다', async () => {
+    const originalUptime = process.uptime;
+    process.uptime = () => {
+      throw new Error('uptime failed');
+    };
+
+    const req = new NextRequest('http://localhost/api/health', { method: 'GET' });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe('unhealthy');
+
+    process.uptime = originalUptime;
+  });
+});


### PR DESCRIPTION
## Summary
- return 200 instead of 503 from health API catch block
- log that server continues running when health check fails
- add integration tests for health API success and failure cases

## Testing
- `npm run test:integration` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68461c093c98832586fb7d1b5b259f67