### PR TITLE
fix cleanup api script

### DIFF
--- a/development/scripts/analysis/cleanup-apis.mjs
+++ b/development/scripts/analysis/cleanup-apis.mjs
@@ -1,13 +1,8 @@
 #!/usr/bin/env node
 
-/**
- * 🧹 자동 생성된 API 정리 스크립트
- * 생성일: 2025-06-10T11:22:41.538Z
- * 정리 대상: 0개 API
- */
-
 import fs from 'fs';
 import path from 'path';
+import APICleanupAnalyzer from './api-cleanup-analyzer.mjs';
 
 const APIS_TO_REMOVE = [
 
@@ -46,6 +41,6 @@ function cleanup() {
 
 // 실행
 const analyzer = new APICleanupAnalyzer();
-analyzer.analyze().catch(console.error);
+analyzer.analyze().then(cleanup);
 
 export { cleanup };


### PR DESCRIPTION
## Summary
- remove wrong strings and incomplete header in cleanup script
- add missing `APICleanupAnalyzer` import
- run cleanup after analysis completes

## Testing
- `npm run test:unit` *(fails: ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_685276153ce4832584b26981ebc23251