### PR TITLE
Fix api cleanup analyzer footer

### DIFF
--- a/development/scripts/analysis/api-cleanup-analyzer.mjs
+++ b/development/scripts/analysis/api-cleanup-analyzer.mjs
@@ -295,8 +295,5 @@ export { cleanup };
     }
 }
 
-// 실행
-const analyzer = new APICleanupAnalyzer();
-analyzer.analyze().catch(console.error);
 
-export default APICleanupAnalyzer; 
+export default APICleanupAnalyzer;


### PR DESCRIPTION
## Summary
- remove stray execution lines from `api-cleanup-analyzer.mjs`
- ensure file ends cleanly with `export default APICleanupAnalyzer;`

## Testing
- `node development/scripts/analysis/api-cleanup-analyzer.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6852761164fc832597d9140172f82355